### PR TITLE
fix: Use day instaed of month in the PR title

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           echo "year=$(date -u "+%Y")" >> $GITHUB_OUTPUT
           echo "date=$(date -u "+%d-%m-%y")" >> $GITHUB_OUTPUT
-          echo "readableDate=$(date -u "+%b %m, %Y")" >> $GITHUB_OUTPUT
+          echo "readableDate=$(date -u "+%b %d, %Y")" >> $GITHUB_OUTPUT
 
       - name: 🛫 Setting up Deno
         uses: denoland/setup-deno@v1
@@ -28,7 +28,7 @@ jobs:
 
       - name: 🗓️ Creating directory for the year
         run: mkdir -p ${{ steps.environment.outputs.year }}
-      
+
       - name: 📜 Generating CHANGELOG
         run: |
           export CHANGELOG_GITHUB_TOKEN=${{ secrets.CHANGELOG_GITHUB_TOKEN}}


### PR DESCRIPTION
## Description

Seems like the PR title got changed and was not correct. Use `d` instead of `m`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
