### PR TITLE
fix: run pr validate on reopen

### DIFF
--- a/.github/workflows/validate_pr.yaml
+++ b/.github/workflows/validate_pr.yaml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     types:
       - opened
+      - reopened
       - edited
       - synchronize
 


### PR DESCRIPTION
## Description

Working around PR bot restrictions means this needs to run on reopened as well

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
